### PR TITLE
Refactor: Improve Versioning and Release APK Naming

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,7 +1,21 @@
 import org.gradle.kotlin.dsl.android
 import org.gradle.kotlin.dsl.dependencies
-import java.util.Properties
-import java.io.FileInputStream
+
+fun getVersionCode(): Int {
+    return if (project.hasProperty("appVersionCode")) {
+        project.property("appVersionCode").toString().toInt()
+    } else {
+        1
+    }
+}
+
+fun getVersionName(): String {
+    return if (project.hasProperty("appVersionName")) {
+        project.property("appVersionName").toString()
+    } else {
+        "1.0-LOCAL"
+    }
+}
 
 plugins {
     alias(libs.plugins.androidApplication)
@@ -21,21 +35,19 @@ android {
         applicationId = "com.example.v5rules"
         minSdk = 25
         targetSdk = 36
-        versionCode = 1
-        versionName = "1.0"
+        // Corretto: Usiamo solo le chiamate alle funzioni, senza duplicati.
+        versionCode = getVersionCode()
+        versionName = getVersionName()
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {
             useSupportLibrary = true
         }
-
     }
+
     signingConfigs {
         create("release") {
-            // FIXED: The path now points to the project root directory, matching the workflow
             val keystoreFile = rootProject.file("keystore.jks")
-
-            // This logic is now correct. If the file exists, the properties will be set.
             if (keystoreFile.exists()) {
                 storeFile = keystoreFile
                 storePassword = System.getenv("SIGNING_STORE_PASSWORD")
@@ -53,6 +65,14 @@ android {
                 "proguard-rules.pro"
             )
             signingConfig = signingConfigs.getByName("release")
+        }
+    }
+    applicationVariants.all {
+        if (buildType.name == "release") {
+            outputs.all {
+                val outputImpl = this as com.android.build.gradle.internal.api.BaseVariantOutputImpl
+                outputImpl.outputFileName = "V5Rules-${versionName}.apk"
+            }
         }
     }
 


### PR DESCRIPTION
This commit introduces functions to dynamically set `versionCode` and `versionName` and customizes the output APK name for release builds.

- **Dynamic Versioning (`app/build.gradle.kts`):**
    - Added `getVersionCode()` function to read `versionCode` from project properties or default to 1.
    - Added `getVersionName()` function to read `versionName` from project properties or default to "1.0-LOCAL".
    - `defaultConfig` now uses these functions to set `versionCode` and `versionName`.
    - Removed unused imports for `Properties` and `FileInputStream`.

- **Custom Release APK Naming (`app/build.gradle.kts`):**
    - Added an `applicationVariants.all` block.
    - For "release" build types, the output APK file name is now set to `V5Rules-${versionName}.apk`.

- **Signing Config (`app/build.gradle.kts`):**
    - Removed commented-out code and explanatory comments within the "release" `signingConfigs` block as the logic is now established.