### PR TITLE
feat: Remove Italian comment from Proguard rules

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -11,7 +11,6 @@
 -keep class com.google.firebase.** { *; }
 -keepattributes Signature, InnerClasses
 
-# Regole per classi di sistema referenziate da dipendenze comuni
 # Risolve: sun.misc.Unsafe, javax.naming.*
 # noinspection ShrinkerUnresolvedReference
 -keep class sun.misc.Unsafe { *; }


### PR DESCRIPTION
This commit removes an Italian comment from the Proguard rules file.