### PR TITLE
feat: Remove @StringRes annotation

### DIFF
--- a/app/src/main/java/com/example/v5rules/BottomNavItem.kt
+++ b/app/src/main/java/com/example/v5rules/BottomNavItem.kt
@@ -1,13 +1,12 @@
 package com.example.v5rules
 
-import androidx.annotation.StringRes
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccountBox
 import androidx.compose.material.icons.filled.Home
 import androidx.compose.material.icons.filled.Menu
 import androidx.compose.ui.graphics.vector.ImageVector
 
-sealed class BottomNavItem(val route: Any, val icon: ImageVector, @StringRes val title: Int) {
+sealed class BottomNavItem(val route: Any, val icon: ImageVector, val title: Int) {
     object Home : BottomNavItem(HomeNav, Icons.Filled.Home, R.string.home)
     object Rules : BottomNavItem(RulesNav, Icons.Filled.Menu, R.string.rules)
     object Character : BottomNavItem(CharacterSheetListNav, Icons.Filled.AccountBox, R.string.characters)


### PR DESCRIPTION
The `@StringRes` annotation was removed from the `title` parameter in the `BottomNavItem` class constructor. This change implies that the `title` parameter might not always be a string resource ID.